### PR TITLE
StakableBar style fixes

### DIFF
--- a/src/features/staking/subcomponents/StakableBar.tsx
+++ b/src/features/staking/subcomponents/StakableBar.tsx
@@ -1,5 +1,5 @@
 import { BsCircleFill } from "react-icons/bs";
-import { twMerge } from "tailwind-merge";
+import { twJoin, twMerge } from "tailwind-merge";
 import { useTokenBalances } from "../../../hooks/useTokenBalances";
 import "../../../index.css";
 import { calculateTokenProportions } from "../utils/calculateTokenProportions";
@@ -18,12 +18,17 @@ export const StakableBar = ({ className }: { className?: string }) => {
       stakable: +stakable,
     });
 
+  const zeroBalance = !unstakablePercent && !stakedPercent && !stakablePercent;
+
   return (
     <div className={twMerge("flex w-full flex-col gap-4", className)}>
       <div className="m-auto flex h-2 mb-2 w-full flex-row rounded-full">
         <div
           style={{ flexBasis: `${unstakablePercent}%` }}
-          className="checkered-blue rounded-l-full min-w-[3px]"
+          className={twJoin(
+            "checkered-blue rounded-l-full",
+            zeroBalance ? "min-w-0" : "min-w-[3px]",
+          )}
         ></div>
         <div
           style={{ flexBasis: `${stakedPercent}%` }}
@@ -31,7 +36,10 @@ export const StakableBar = ({ className }: { className?: string }) => {
         ></div>
         <div
           style={{ flexBasis: `${stakablePercent}%` }}
-          className="rounded-r-full bg-gray-500 min-w[3px]"
+          className={twJoin(
+            "bg-gray-500 min-w[3px]",
+            zeroBalance ? "w-full rounded-full" : "rounded-r-full",
+          )}
         ></div>
       </div>
 


### PR DESCRIPTION
If a user has no balance, the bar wasn't showing up properly. With the changes, it checks if a user has any AST balance, and if not, it renders "stakable" as 0, but taking up the full width.

Before:
<img width="380" alt="Screenshot 2023-09-19 at 9 17 48 PM" src="https://github.com/airswap/airswap-voter-rewards/assets/90465420/5b9c422b-6aba-4498-b186-750aca09cbd6">

After:
<img width="382" alt="Screenshot 2023-09-19 at 9 17 07 PM" src="https://github.com/airswap/airswap-voter-rewards/assets/90465420/e0bde8e1-4715-4ee6-a97b-7b5ebd4f6b35">
