### PR TITLE
Updates to caching

### DIFF
--- a/src/features/votes/SetRootButton.tsx
+++ b/src/features/votes/SetRootButton.tsx
@@ -39,7 +39,9 @@ export const SetRootButton = ({
   // Calculate the root when we have one
   const { data: merkleRoot } = useGroupMerkleRoot(
     proposalGroup.map((p) => p.id),
-    { enabled: !!isPoolAdmin && existingRoot === null },
+    // Note: hasEnded is not strictly necessary here as (`existingRoot` will be
+    // undefined not null), but we include it for clarity.
+    { enabled: !!isPoolAdmin && existingRoot === null && hasEnded },
   );
 
   // Write the root

--- a/src/features/votes/hooks/useGroupClaimStatus.ts
+++ b/src/features/votes/hooks/useGroupClaimStatus.ts
@@ -24,6 +24,8 @@ export const useGroupClaimStatus = ({
       treeId: groupHash,
     });
 
+  // TODO: this could be more efficient - we only need votes to calculate points
+  // so we don't really need to cache the votes themselves here.
   // Fetch all user votes.
   const { data: userVotes } = useUserVotes(address);
 

--- a/src/features/votes/hooks/useGroupMerkleRoot.ts
+++ b/src/features/votes/hooks/useGroupMerkleRoot.ts
@@ -1,21 +1,23 @@
-import { useQuery } from "wagmi";
+import { useQuery, useQueryClient } from "wagmi";
 import { useGroupMerkleTree } from "./useGroupMerkleTree";
 
 export const useGroupMerkleRoot = (
   proposalIds: string[],
   options?: { enabled: boolean },
 ) => {
+  const queryKey = ["group-merkle-root", proposalIds];
+  const queryClient = useQueryClient();
+
+  // Prevent fetching the merkle tree (lots of data) if we already have the root.
+  const cachedRoot = queryClient.getQueryData(queryKey);
+
   const tree = useGroupMerkleTree(proposalIds, {
-    enabled: options?.enabled ?? true,
+    enabled: !cachedRoot && (options?.enabled ?? true),
   });
 
-  return useQuery(
-    ["group-merkle-root", proposalIds],
-    () => tree!.getHexRoot() as `0x${string}`,
-    {
-      enabled: (options?.enabled ?? true) && !!tree,
-      cacheTime: Infinity,
-      staleTime: Infinity,
-    },
-  );
+  return useQuery(queryKey, () => tree!.getHexRoot() as `0x${string}`, {
+    enabled: (options?.enabled ?? true) && !!tree,
+    cacheTime: 5_184_000_000, // 2 months.
+    staleTime: Infinity, // doesn't change
+  });
 };

--- a/src/features/votes/hooks/useGroupedProposals.ts
+++ b/src/features/votes/hooks/useGroupedProposals.ts
@@ -69,7 +69,9 @@ export const useGroupedProposals = () => {
   };
 
   return useQuery([snapshot.endpoint, snapshot.space, "proposals"], fetch, {
-    cacheTime: Infinity,
+    cacheTime: 604_800_000, // 7 days
     staleTime: 3_600_000, // 1 hour
+    refetchInterval: 3_600_000, // 1 hour
+    refetchIntervalInBackground: false,
   });
 };

--- a/src/features/votes/hooks/useHasClaimedForTree.ts
+++ b/src/features/votes/hooks/useHasClaimedForTree.ts
@@ -23,8 +23,8 @@ export const useHasClaimedForTree = ({
     functionName: "claimed",
     args: [treeId, _voterAddress!],
     enabled: !!voterAddress,
-    // 7 days
-    cacheTime: 604_800_000,
+    // 60d
+    cacheTime: 5_184_000_000,
     staleTime: 604_800_000,
   });
 };

--- a/src/features/votes/hooks/useProposalGroupVotes.ts
+++ b/src/features/votes/hooks/useProposalGroupVotes.ts
@@ -55,10 +55,9 @@ export const useProposalGroupVotes = (
     [snapshot.endpoint, "votesByProposalIds", proposalIds],
     fetch,
     {
-      // FIXME: remove all Infinity caches and have a configurable cache time
-      cacheTime: Infinity,
-      // TODO: Should be possible to increase this to be much more aggresively cached
-      // if we ensure that this is only requested for closed proposals.
+      // Note that this is a large payload, and we want to avoid caching it for
+      // extended amounts of time.
+      cacheTime: 600_000, // 10 minutes
       staleTime: 600_000, // 10 minutes
       enabled:
         !!proposalIds && proposalIds.length > 0 && (options?.enabled ?? true),

--- a/src/features/votes/hooks/useUserVotes.ts
+++ b/src/features/votes/hooks/useUserVotes.ts
@@ -16,11 +16,9 @@ const VOTES_QUERY = (space: string, voter?: string) => gql`
       orderBy: "created"
       orderDirection: desc
     ) {
-      id
       proposal {
         id
       }
-      choice
       vp
     }
   }
@@ -28,8 +26,6 @@ const VOTES_QUERY = (space: string, voter?: string) => gql`
 
 type VotesQueryResult = {
   votes: {
-    id: string;
-    choice: number;
     vp: number;
     proposal: { id: string };
   }[];
@@ -61,7 +57,7 @@ export const useUserVotes = (voter?: `0x${string}`) => {
     ],
     fetch,
     {
-      cacheTime: Infinity,
+      cacheTime: 600_000,
       staleTime: 600_000, // 10 minutes
       enabled: !!_voter,
     },


### PR DESCRIPTION
This PR mostly focuses on ensuring we don't over-cache things.

Most notably, `useGroupMerkleProof` and `useGroupMerkleRoot` now disable the `useGroupMerkleTree` hook if they already have a value cached. In turn `useGroupMerkleTree` therefore disables `useProposalGroupVotes` to prevent fetching every vote for proposals when they are not needed.

We can then reduce the cache time of the votes to just 10 minutes, as we cache the smaller roots and proofs for much longer.

Individual cache and stale times have also been adjusted appropriately.