### PR TITLE
Prompt to switch chains before a transaction

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,9 @@
-import { useEffect } from "react";
-import { useAccount, useNetwork, useSwitchNetwork } from "wagmi";
 import { Header } from "./features/structure/Header";
 import { VoteList } from "./features/votes/VoteList";
 import { useApplyTheme } from "./hooks/useApplyTheme";
 
 function App() {
   useApplyTheme();
-  const { chain } = useNetwork();
-  const { isConnected } = useAccount();
-
-  const { switchNetwork } = useSwitchNetwork({
-    throwForSwitchChainNotSupported: true,
-  });
-
-  useEffect(() => {
-    if (chain?.id === 1 || chain?.id === 5) {
-      null;
-    } else if (isConnected) {
-      switchNetwork && switchNetwork(1);
-    }
-  }, [chain?.id, isConnected, switchNetwork]);
 
   return (
     <div className="flex flex-col flex-1 h-full">

--- a/src/features/claims/ClaimForm.tsx
+++ b/src/features/claims/ClaimForm.tsx
@@ -8,12 +8,14 @@ import {
   useContractWrite,
   usePrepareContractWrite,
   usePublicClient,
+  useSwitchNetwork,
 } from "wagmi";
 import { ContractTypes } from "../../config/ContractAddresses";
 import { useContractAddresses } from "../../config/hooks/useContractAddress";
 import { poolAbi } from "../../contracts/poolAbi";
 import { Button } from "../common/Button";
 import { TransactionTracker } from "../common/TransactionTracker";
+import { useIsSupportedChain } from "../common/hooks/useIsSupportedChain";
 import { useClaimSelectionStore } from "../votes/store/useClaimSelectionStore";
 import {
   ClaimableTokensLineItem,
@@ -31,6 +33,9 @@ export const ClaimForm = ({}: {}) => {
 
   const chainId = useChainId();
   const publicClient = usePublicClient({ chainId: chainId });
+
+  const isSupportedChain = useIsSupportedChain();
+  const { switchNetwork, isLoading: switchNetworkLoading } = useSwitchNetwork();
 
   const [
     pointsClaimableByEpoch,
@@ -220,20 +225,34 @@ export const ClaimForm = ({}: {}) => {
           )}
         </div>
       </div>
-      <Button
-        color="primary"
-        rounded={false}
-        className="mt-7"
-        onClick={() => {
-          if (write) {
-            write();
-            setPointsUsed(pointsSelected);
-          }
-        }}
-        disabled={selection === undefined || !write}
-      >
-        Claim
-      </Button>
+      {isSupportedChain ? (
+        <Button
+          color="primary"
+          rounded={false}
+          className="mt-7"
+          onClick={() => {
+            if (write) {
+              write();
+              setPointsUsed(pointsSelected);
+            }
+          }}
+          disabled={selection === undefined || !write}
+        >
+          Claim
+        </Button>
+      ) : (
+        <Button
+          color="primary"
+          rounded={false}
+          className="mt-7"
+          disabled={switchNetworkLoading || !switchNetwork}
+          onClick={() => {
+            switchNetwork?.(1);
+          }}
+        >
+          Switch to Ethereum
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/features/claims/hooks/useClaimCalculations.ts
+++ b/src/features/claims/hooks/useClaimCalculations.ts
@@ -1,4 +1,4 @@
-import { useChainId, useQuery } from "wagmi";
+import { useNetwork, useQuery } from "wagmi";
 import { multicall } from "wagmi/actions";
 import { ContractTypes } from "../../../config/ContractAddresses";
 import { useContractAddresses } from "../../../config/hooks/useContractAddress";
@@ -8,7 +8,7 @@ export const useClaimCalculations = (
   points: number,
   claimableTokens: `0x${string}`[],
 ) => {
-  const chainId = useChainId();
+  const { chain } = useNetwork();
   const [poolContract] = useContractAddresses([ContractTypes.AirSwapPool], {
     useDefaultAsFallback: false,
     alwaysUseDefault: false,
@@ -18,7 +18,7 @@ export const useClaimCalculations = (
   const fetch = async () => {
     if (!poolContract.address) return;
     const multicallResponse = await multicall({
-      chainId,
+      chainId: chain!.id,
       contracts: claimableTokens.map((tokenAddress) => ({
         address: poolContract.address!,
         abi: poolAbi,
@@ -31,9 +31,9 @@ export const useClaimCalculations = (
     return multicallResponse.map((response) => response.result || 0n);
   };
 
-  return useQuery(["claimCalculations", chainId, points], fetch, {
+  return useQuery(["claimCalculations", chain!.id, points], fetch, {
     enabled: Boolean(
-      _points > 0 && poolContract.address && claimableTokens.length,
+      _points > 0 && poolContract.address && claimableTokens.length && chain,
     ),
     // 1 minute
     cacheTime: 60_000,

--- a/src/features/common/hooks/useIsSupportedChain.ts
+++ b/src/features/common/hooks/useIsSupportedChain.ts
@@ -1,0 +1,6 @@
+import { useNetwork } from "wagmi";
+
+export const useIsSupportedChain = () => {
+  const { chain } = useNetwork();
+  return chain?.id === 1 || chain?.id === 5;
+};

--- a/src/features/staking/StakingModal.tsx
+++ b/src/features/staking/StakingModal.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { useWaitForTransaction } from "wagmi";
+import { useSwitchNetwork, useWaitForTransaction } from "wagmi";
 import { useTokenBalances } from "../../hooks/useTokenBalances";
 import { Button } from "../common/Button";
 import { Modal } from "../common/Modal";
 import { TransactionTracker } from "../common/TransactionTracker";
+import { useIsSupportedChain } from "../common/hooks/useIsSupportedChain";
 import { ManageStake } from "./ManageStake";
 import { useApproveAst } from "./hooks/useApproveAst";
 import { useAstAllowance } from "./hooks/useAstAllowance";
@@ -22,6 +23,9 @@ export const StakingModal = () => {
   const formReturn = useForm();
   const { getValues } = formReturn;
   const stakingAmount = getValues().stakingAmount;
+
+  const isSupportedChain = useIsSupportedChain();
+  const { switchNetwork } = useSwitchNetwork();
 
   // This state tracks whether the last transaction was an approval.
   const [isApproval, setIsApproval] = useState<boolean>(false);
@@ -99,9 +103,11 @@ export const StakingModal = () => {
   });
 
   const modalButtonAction = modalButtonActionsAndText({
+    isSupportedNetwork: isSupportedChain,
     txType,
     needsApproval,
     buttonActions: {
+      switchNetwork: () => switchNetwork?.(1),
       approve: approveAst,
       stake: stakeAst,
       unstake: unstakeSast,

--- a/src/features/staking/utils/modalButtonActionsAndText.ts
+++ b/src/features/staking/utils/modalButtonActionsAndText.ts
@@ -5,20 +5,28 @@ type ButtonActions = {
   approve: (() => Promise<WriteContractResult>) | undefined;
   stake: (() => Promise<WriteContractResult>) | undefined;
   unstake: (() => Promise<WriteContractResult>) | undefined;
+  switchNetwork: (() => void) | undefined;
 };
 
 export const modalButtonActionsAndText = ({
+  isSupportedNetwork,
   txType,
   needsApproval,
   buttonActions,
   insufficientBalance,
 }: {
+  isSupportedNetwork: boolean;
   txType: TxType;
   needsApproval: boolean;
   buttonActions: ButtonActions;
   insufficientBalance?: boolean;
 }) => {
-  if (insufficientBalance) {
+  if (!isSupportedNetwork) {
+    return {
+      label: "Switch to Ethereum",
+      callback: buttonActions.switchNetwork,
+    };
+  } else if (insufficientBalance) {
     return {
       label: "Insufficient balance",
       callback: () => null,


### PR DESCRIPTION
If a user is on the wrong chain when they open the stake or claim modal, we prompt them to switch to ethereum.

<img width="388" alt="image" src="https://github.com/airswap/airswap-voter-rewards/assets/82473383/56c08017-b289-4a5e-a228-a208e885f28a">
