### PR TITLE
Proposal list + number formatting fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@fontsource/dm-mono": "^5.0.14",
-    "@greypixel_/nicenumbers": "^0.0.20",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@react-hooks-library/core": "^0.5.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,20 @@
 import { Header } from "./features/structure/Header";
+import { ClaimFloat } from "./features/votes/ClaimFloat";
 import { VoteList } from "./features/votes/VoteList";
+import { useClaimSelectionStore } from "./features/votes/store/useClaimSelectionStore";
 import { useApplyTheme } from "./hooks/useApplyTheme";
 
 function App() {
   useApplyTheme();
+  const { setShowClaimModal } = useClaimSelectionStore();
 
   return (
-    <div className="flex flex-col flex-1 h-full">
+    <div className="flex flex-col flex-1 h-full items-center">
       <Header />
       <main className="mx-auto flex w-[808px] p-2 max-w-full flex-col flex-1">
         <VoteList />
       </main>
+      <ClaimFloat onClaimClicked={() => setShowClaimModal(true)} />
     </div>
   );
 }

--- a/src/features/activate-migration/ActivatePointsCard.tsx
+++ b/src/features/activate-migration/ActivatePointsCard.tsx
@@ -1,9 +1,9 @@
-import { format } from "@greypixel_/nicenumbers";
 import { motion } from "framer-motion";
 import { useEffect } from "react";
 import { twJoin, twMerge } from "tailwind-merge";
 import { Checkbox } from "../common/Checkbox";
 import { CheckMark } from "../common/icons/CheckMark";
+import { formatNumber } from "../common/utils/formatNumber";
 import { useHasClaimedForTree } from "../votes/hooks/useHasClaimedForTree";
 import { useClaimSelectionStore } from "../votes/store/useClaimSelectionStore";
 import { ACTIVATE_TREE_ID } from "./constants";
@@ -100,11 +100,7 @@ export const ActivatePointsCard = ({}: {}) => {
               </span>
             )}
             {/* TODO: small numbers of points probably don't need decimals. */}
-            {format(activateMigrationClaim?.value, {
-              tokenDecimals: 0,
-              significantFigures: 3,
-              minDecimalPlaces: 0,
-            })}
+            {formatNumber(activateMigrationClaim?.value)}
             &nbsp; Points {hasUserClaimed && " claimed "}
           </div>
         </div>

--- a/src/features/claims/ClaimForm.tsx
+++ b/src/features/claims/ClaimForm.tsx
@@ -1,4 +1,3 @@
-import { format } from "@greypixel_/nicenumbers";
 import BigNumber from "bignumber.js";
 import { useState } from "react";
 import { decodeEventLog, zeroAddress } from "viem";
@@ -16,6 +15,7 @@ import { poolAbi } from "../../contracts/poolAbi";
 import { Button } from "../common/Button";
 import { TransactionTracker } from "../common/TransactionTracker";
 import { useIsSupportedChain } from "../common/hooks/useIsSupportedChain";
+import { formatNumber } from "../common/utils/formatNumber";
 import { useClaimSelectionStore } from "../votes/store/useClaimSelectionStore";
 import {
   ClaimableTokensLineItem,
@@ -159,10 +159,10 @@ export const ClaimForm = ({}: {}) => {
     <span>
       You successfully claimed{" "}
       <span className="w-20 text-white">
-        {format(withdrawnAmount, { tokenDecimals: selection?.tokenDecimals })}{" "}
+        {formatNumber(withdrawnAmount, selection?.tokenDecimals)}{" "}
         {selection?.tokenSymbol || "tokens"}
       </span>{" "}
-      using {pointsUsed} points
+      using {formatNumber(pointsUsed)} points
     </span>
   ) : (
     <span>
@@ -170,7 +170,7 @@ export const ClaimForm = ({}: {}) => {
       <span className="inline-block w-14 bg-gray-400 animate-pulse h-3" />
       &nbsp;
       <span className="inline-block w-8 bg-gray-400 animate-pulse h-3" />
-      &nbsp;tokens using {pointsUsed} points
+      &nbsp;tokens using {formatNumber(pointsUsed)} points
     </span>
   );
 

--- a/src/features/claims/ClaimModalSubheading.tsx
+++ b/src/features/claims/ClaimModalSubheading.tsx
@@ -1,3 +1,4 @@
+import { formatNumber } from "../common/utils/formatNumber";
 import { useClaimSelectionStore } from "../votes/store/useClaimSelectionStore";
 
 export const ClaimModalSubheading = ({}: {}) => {
@@ -22,7 +23,8 @@ export const ClaimModalSubheading = ({}: {}) => {
 
   return (
     <span>
-      Using {pointsSelected} out of {totalPointsClaimable} points
+      Using {formatNumber(pointsSelected)} out of{" "}
+      {formatNumber(totalPointsClaimable)} points
     </span>
   );
 };

--- a/src/features/claims/ClaimableTokensLineItem.tsx
+++ b/src/features/claims/ClaimableTokensLineItem.tsx
@@ -33,7 +33,7 @@ export const ClaimableTokensLineItem = ({
       </span>
       <span
         className={twJoin(
-          "text-white font-medium",
+          "text-white font-medium text-right",
           amount != null ? "opacity-100" : "opacity-0",
           "transition-opacity",
         )}

--- a/src/features/claims/ClaimableTokensLineItem.tsx
+++ b/src/features/claims/ClaimableTokensLineItem.tsx
@@ -1,6 +1,6 @@
-import { format } from "@greypixel_/nicenumbers";
 import { twJoin } from "tailwind-merge";
 import { Checkbox } from "../common/Checkbox";
+import { formatNumber } from "../common/utils/formatNumber";
 
 export const ClaimableTokensLineItem = ({
   symbol,
@@ -25,11 +25,7 @@ export const ClaimableTokensLineItem = ({
         onCheckedChange={(state) => state === true && onSelect()}
       />
       <span className="text-gray-400">
-        {format(amount, {
-          tokenDecimals: decimals,
-          significantFigures: 3,
-        })}{" "}
-        {symbol}
+        {formatNumber(amount, decimals)} {symbol}
       </span>
       <span
         className={twJoin(

--- a/src/features/common/utils/convertDecimalPlaces.ts
+++ b/src/features/common/utils/convertDecimalPlaces.ts
@@ -1,4 +1,0 @@
-export const convertDecimalPlaces = (balance: bigint) => {
-  const formattedBalance = Number(balance) / 10**4;
-  return formattedBalance.toLocaleString(navigator.language, {maximumFractionDigits: 2, notation: "compact"})
-}

--- a/src/features/common/utils/formatNumber.ts
+++ b/src/features/common/utils/formatNumber.ts
@@ -1,0 +1,23 @@
+import BigNumber from "bignumber.js";
+
+export const formatNumber = (
+  number?: number | bigint,
+  decimals: number | null = null,
+) => {
+  if (!number) return undefined;
+  let _number;
+  if (decimals) {
+    _number = new BigNumber(number.toString())
+      .dividedBy(10 ** decimals)
+      .toNumber();
+  } else {
+    _number = number;
+  }
+  return _number.toLocaleString(window.navigator.language, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+    minimumSignificantDigits: 3,
+    maximumSignificantDigits: 3,
+    notation: "compact",
+  });
+};

--- a/src/features/staking/ManageStake.tsx
+++ b/src/features/staking/ManageStake.tsx
@@ -4,7 +4,7 @@ import AirSwapLogo from "../../assets/airswap-logo.svg";
 import { useTokenBalances } from "../../hooks/useTokenBalances";
 import { Button } from "../common/Button";
 import { LineBreak } from "../common/LineBreak";
-import { convertDecimalPlaces } from "../common/utils/convertDecimalPlaces";
+import { formatNumber } from "../common/utils/formatNumber";
 import { NumberInput } from "./NumberInput";
 import { PieBar } from "./PieBar";
 import { useStakingModalStore } from "./store/useStakingModalStore";
@@ -24,8 +24,8 @@ export const ManageStake = ({
     astBalanceRaw: stakableBalance,
   } = useTokenBalances();
 
-  const stakableBalanceFormatted = convertDecimalPlaces(stakableBalance);
-  const unstakableBalanceFormatted = convertDecimalPlaces(unstakableBalance);
+  const stakableBalanceFormatted = formatNumber(stakableBalance, 4);
+  const unstakableBalanceFormatted = formatNumber(unstakableBalance, 4);
 
   const handleSetMaxBalance = () => {
     if (txType === TxType.STAKE) {

--- a/src/features/staking/PieBar.tsx
+++ b/src/features/staking/PieBar.tsx
@@ -2,16 +2,16 @@ import { BsCircleFill } from "react-icons/bs";
 import { twJoin } from "tailwind-merge";
 import { useTokenBalances } from "../../hooks/useTokenBalances";
 import "../../index.css";
-import { convertDecimalPlaces } from "../common/utils/convertDecimalPlaces";
+import { formatNumber } from "../common/utils/formatNumber";
 import { calculateTokenProportions } from "./utils/calculateTokenProportions";
 
 export const PieBar = () => {
   const { unstakableSastBalanceRaw, sAstBalanceRaw, astBalanceRaw } =
     useTokenBalances();
 
-  const stakable = convertDecimalPlaces(astBalanceRaw);
-  const staked = convertDecimalPlaces(sAstBalanceRaw);
-  const unstakable = convertDecimalPlaces(unstakableSastBalanceRaw);
+  const stakable = formatNumber(astBalanceRaw, 4);
+  const staked = formatNumber(sAstBalanceRaw, 4);
+  const unstakable = formatNumber(unstakableSastBalanceRaw, 4);
 
   const { unstakablePercent, stakedPercent, stakablePercent } =
     calculateTokenProportions({

--- a/src/features/staking/StakingButton.tsx
+++ b/src/features/staking/StakingButton.tsx
@@ -2,7 +2,7 @@ import { twJoin } from "tailwind-merge";
 import { useAccount } from "wagmi";
 import { useTokenBalances } from "../../hooks/useTokenBalances";
 import { Button } from "../common/Button";
-import { convertDecimalPlaces } from "../common/utils/convertDecimalPlaces";
+import { formatNumber } from "../common/utils/formatNumber";
 import { StakingModal } from "./StakingModal";
 import { useStakingModalStore } from "./store/useStakingModalStore";
 
@@ -11,7 +11,7 @@ export const StakingButton = () => {
   const { isConnected } = useAccount();
   const { unstakableSastBalanceRaw } = useTokenBalances();
 
-  const sAstBalance = convertDecimalPlaces(unstakableSastBalanceRaw);
+  const sAstBalance = formatNumber(unstakableSastBalanceRaw, 4);
 
   return (
     <>

--- a/src/features/staking/hooks/useAstAllowance.ts
+++ b/src/features/staking/hooks/useAstAllowance.ts
@@ -1,8 +1,8 @@
-import { format } from "@greypixel_/nicenumbers";
 import { useAccount, useContractRead, useNetwork } from "wagmi";
 import { ContractTypes } from "../../../config/ContractAddresses";
 import { useContractAddresses } from "../../../config/hooks/useContractAddress";
 import { astAbi } from "../../../contracts/astAbi";
+import { formatNumber } from "../../common/utils/formatNumber";
 
 export const useAstAllowance = () => {
   const { address } = useAccount();
@@ -29,7 +29,7 @@ export const useAstAllowance = () => {
     enabled: !!address && !!airSwapStaking.address,
   });
 
-  const astAllowanceFormatted = format(astAllowance, { tokenDecimals: 4 });
+  const astAllowanceFormatted = formatNumber(astAllowance, 4);
 
   return { astAllowance, astAllowanceFormatted };
 };

--- a/src/features/structure/Header.tsx
+++ b/src/features/structure/Header.tsx
@@ -7,7 +7,7 @@ import { StakingButton } from "../staking/StakingButton";
 export const Header = ({}: {}) => {
   const { isConnected } = useAccount();
   return (
-    <div className="flex h-24 flex-row items-center justify-between px-8">
+    <div className="flex h-24 flex-row items-center justify-between px-8 w-full">
       <div>
         <div className="h-10 w-10 md:hidden -mr-5">
           <img

--- a/src/features/votes/ClaimFloat.tsx
+++ b/src/features/votes/ClaimFloat.tsx
@@ -1,9 +1,9 @@
-import { format } from "@greypixel_/nicenumbers";
 import { AnimatePresence, motion } from "framer-motion";
 import { useEffect } from "react";
 import { twJoin } from "tailwind-merge";
 import { useAccount } from "wagmi";
 import { Button } from "../common/Button";
+import { formatNumber } from "../common/utils/formatNumber";
 import { useClaimSelectionStore } from "./store/useClaimSelectionStore";
 
 export const ClaimFloat = ({
@@ -66,12 +66,7 @@ export const ClaimFloat = ({
             </span>
 
             <span className="text-[22px] leading-6 font-bold text-white">
-              {format(totalPointsClaimable, {
-                tokenDecimals: 0,
-                minDecimalPlaces: 0,
-                significantFigures: 3,
-              })}{" "}
-              Points
+              {formatNumber(totalPointsClaimable)} Points
             </span>
           </div>
 

--- a/src/features/votes/ClaimFloat.tsx
+++ b/src/features/votes/ClaimFloat.tsx
@@ -54,7 +54,7 @@ export const ClaimFloat = ({
           key="ClaimPopover"
           className={twJoin(
             // position at bottom of container.
-            "absolute bottom-4 right-0 left-0",
+            "fixed bottom-4 w-[808px]",
             "bg-gray-900 flex flex-row justify-between p-5 rounded-md",
             "border border-gray-800",
             "shadow-[0_0_10px_8px] shadow-[#060607]",

--- a/src/features/votes/PastEpochCard.tsx
+++ b/src/features/votes/PastEpochCard.tsx
@@ -1,4 +1,3 @@
-import { format } from "@greypixel_/nicenumbers";
 import { useEffect, useMemo } from "react";
 import { MdClose, MdOpenInNew } from "react-icons/md";
 import { twJoin, twMerge } from "tailwind-merge";
@@ -6,6 +5,7 @@ import { useAccount } from "wagmi";
 import { Accordion } from "../common/Accordion";
 import { Checkbox } from "../common/Checkbox";
 import { CheckMark } from "../common/icons/CheckMark";
+import { formatNumber } from "../common/utils/formatNumber";
 import { useGroupClaimStatus } from "./hooks/useGroupClaimStatus";
 import { useGroupMerkleProof } from "./hooks/useGroupMerkleProof";
 import { Proposal } from "./hooks/useGroupedProposals";
@@ -193,11 +193,7 @@ export const PastEpochCard = ({
 
         {votedOnAllProposals ? (
           <span>
-            {format(pointsEarned, {
-              tokenDecimals: 0,
-              significantFigures: 3,
-              minDecimalPlaces: 0,
-            })}
+            {formatNumber(pointsEarned)}
             &nbsp; Points {hasUserClaimed && " claimed "}
           </span>
         ) : (

--- a/src/features/votes/PastEpochCard.tsx
+++ b/src/features/votes/PastEpochCard.tsx
@@ -162,7 +162,10 @@ export const PastEpochCard = ({
         </div>
         {/* Title */}
         <div
-          className={twMerge("font-bold", hasUserClaimed && "text-gray-500")}
+          className={twMerge(
+            "font-bold",
+            (hasUserClaimed || !votedOnAllProposals) && "text-gray-500",
+          )}
         >
           {proposalGroupTitle}
         </div>
@@ -173,7 +176,7 @@ export const PastEpochCard = ({
         className={twJoin([
           "rounded-full px-4 py-1 text-xs font-bold uppercase leading-6",
           "flex flex-row items-center gap-2 ring-1 ring-gray-800",
-          hasUserClaimed && "text-gray-500",
+          (hasUserClaimed || !votedOnAllProposals) && "text-gray-500",
         ])}
       >
         {hasUserClaimed && (
@@ -181,13 +184,25 @@ export const PastEpochCard = ({
             <CheckMark size={20} />
           </span>
         )}
+        {!votedOnAllProposals && (
+          <span className="text-red-600">
+            <MdClose size={20} />
+          </span>
+        )}
         {/* TODO: small numbers of points probably don't need decimals. */}
-        {format(pointsEarned, {
-          tokenDecimals: 0,
-          significantFigures: 3,
-          minDecimalPlaces: 0,
-        })}
-        &nbsp; Points {hasUserClaimed && " claimed "}
+
+        {votedOnAllProposals ? (
+          <span>
+            {format(pointsEarned, {
+              tokenDecimals: 0,
+              significantFigures: 3,
+              minDecimalPlaces: 0,
+            })}
+            &nbsp; Points {hasUserClaimed && " claimed "}
+          </span>
+        ) : (
+          <span>Missed</span>
+        )}
       </div>
     </div>
   );

--- a/src/features/votes/VoteList.tsx
+++ b/src/features/votes/VoteList.tsx
@@ -90,11 +90,11 @@ export const VoteList = ({}: {}) => {
                 ))}
               </div>
               {/* Spacer to allow overscroll to cover the height of the claim float. */}
-              <div className="h-28" />
             </>
           )}
 
           <ActivatePointsCard />
+          <div className="h-28" />
         </>
       )}
 

--- a/src/features/votes/VoteList.tsx
+++ b/src/features/votes/VoteList.tsx
@@ -3,7 +3,6 @@ import { ActivatePointsCard } from "../activate-migration/ActivatePointsCard";
 import { ClaimForm } from "../claims/ClaimForm";
 import { ClaimModalSubheading } from "../claims/ClaimModalSubheading";
 import { Modal } from "../common/Modal";
-import { ClaimFloat } from "./ClaimFloat";
 import { LiveVoteCard } from "./LiveVoteCard";
 import { PastEpochCard } from "./PastEpochCard";
 import { SetRootButton } from "./SetRootButton";
@@ -90,6 +89,8 @@ export const VoteList = ({}: {}) => {
                   <PastEpochCard proposalGroup={group} key={group[0].id} />
                 ))}
               </div>
+              {/* Spacer to allow overscroll to cover the height of the claim float. */}
+              <div className="h-28" />
             </>
           )}
 
@@ -98,7 +99,6 @@ export const VoteList = ({}: {}) => {
       )}
 
       {/* Claim Float */}
-      <ClaimFloat onClaimClicked={() => setShowClaimModal(true)} />
 
       {/* Claim modal. */}
       {showClaimModal && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -235,11 +235,6 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@greypixel_/nicenumbers@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@greypixel_/nicenumbers/-/nicenumbers-0.0.20.tgz#f5aa4053a8912f9c745efcde326edc3b18dd7822"
-  integrity sha512-WcfvHTdGaVnQpW0H3DTQGrQt7r5pbzf4pD/Db1/L+ljmXS30Nutiko33ZIJgcrONtSLr1ICt6EiV7lYujzQVjw==
-
 "@humanwhocodes/config-array@^0.11.11":
   version "0.11.11"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.11.tgz#88a04c570dbbc7dd943e4712429c3df09bc32844"


### PR DESCRIPTION
- Adds "missed" state if user didn't vote
- Claims float no longer covers proposals (add a buffer so you can overscroll)
- Claims form has right aligned numbers and better formatting on points
- Migrated away from `@greypixel_/nicenumbers` and made & used a more generic version of `convertDecimalPlaces` (suppots non token values and values for tokens with decimals != 4)