### PR TITLE
Ensure claims round down fractional values

### DIFF
--- a/src/features/claims/ClaimForm.tsx
+++ b/src/features/claims/ClaimForm.tsx
@@ -89,7 +89,9 @@ export const ClaimForm = ({}: {}) => {
       _selectedClaims.map((claim) => ({
         ...claim,
         value: BigInt(
-          new BigNumber(claim.value).multipliedBy(10 ** 4).toFixed(0),
+          new BigNumber(claim.value)
+            .multipliedBy(10 ** 4)
+            .toFixed(0, BigNumber.ROUND_FLOOR),
         ),
       })),
       selection?.tokenAddress || zeroAddress,


### PR DESCRIPTION
When generating merkle trees from a user's points, we are currently using:

```typescript
export const generateMerkleLeaf = (vote: {
  /** Voter address */
  voter: `0x${string}`;
  /** Voter voting power from snapshot. Amount of sAST tokens, will be a float */
  vp: number;
}) =>
  keccak256(
    encodePacked(
      ["address", "uint256"],
      [
        vote.voter,
        BigInt(
          new BigNumber(vote.vp)
            .multipliedBy(10 ** 4)
            .toFixed(0, BigNumber.ROUND_FLOOR),
        ),
      ],
    ),
  );
```

Crucially we're using the ROUND_FLOOR rounding mode in `BigNumber.js`'s `toFixed` method.

The claim form was not using this, so in some fairly rare cases, would be passing a value off by 1 to the `withdraw` function, which would result in an invalid leaf/proof.

Can test with address `0x49E8Cea9202E202dD266dabffC3cB9845FC0634D` against tree `0x9cab49e1c772d5e408b04da1c416dbceca25cee9b5bab7fac59c3a01ddfb8678` if needed.