### PR TITLE
Fix bug causing unexpected cancel behaviour

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -27,5 +27,6 @@ module.exports = {
     // typescript does this by default.
     "@typescript-eslint/no-unused-vars": 0,
     "@typescript-eslint/ban-ts-comment": 0,
+    "@typescript-eslint/no-explicit-any": 0,
   },
 };

--- a/src/features/claims/ClaimForm.tsx
+++ b/src/features/claims/ClaimForm.tsx
@@ -136,10 +136,14 @@ export const ClaimForm = ({}: {}) => {
         }
       }
     },
-    onError: (e) => {
-      resetClaimStatuses();
-      clearSelectedClaims();
-      refetchClaimable();
+    onError: (e: any) => {
+      if (e?.cause?.code === 4001) {
+        // Do nothing here, the user rejected the tx
+      } else {
+        // There may have been a claim that caused excessive slippage.
+        resetClaimStatuses();
+        refetchClaimable();
+      }
     },
   });
 


### PR DESCRIPTION
Currently if a user cancels a claim transaction, the resets their current selection but does not close the modal.

This means they are then presented with a modal showing the amounts if they claim with **ALL** of their points, and they may do so inadvertendly.