### PR TITLE
V3 -> V4 staking migration modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useAccount } from "wagmi";
+import { MigrationModal } from "./features/staking/MigrationModal";
 import { DisconnectedState } from "./features/structure/DisconnectedState";
 import { Header } from "./features/structure/Header";
 import { ClaimFloat } from "./features/votes/ClaimFloat";
@@ -17,6 +18,7 @@ function App() {
       <main className="mx-auto flex w-[808px] p-0 xs:p-2 max-w-full flex-col flex-1">
         {isConnected ? <VoteList /> : <DisconnectedState />}
       </main>
+      <MigrationModal />
       <ClaimFloat onClaimClicked={() => setShowClaimModal(true)} />
     </div>
   );

--- a/src/config/ContractAddresses.ts
+++ b/src/config/ContractAddresses.ts
@@ -19,8 +19,10 @@ export const contractAddressesByChain: Record<number, ContractList> = {
   5: {
     // goerli
     [ContractTypes.AirSwapToken]: "0x1a1ec25DC08e98e5E93F1104B5e5cdD298707d31",
-    [ContractTypes.AirSwapStaking]:
+    [ContractTypes.AirSwapV3Staking_deprecated]:
       "0x51F372bE64F0612532F28142cECF8F204B272622",
+    [ContractTypes.AirSwapStaking]:
+      "0x3BeC6526366cb2C2A609eb2bCeC8A696C141a33e",
     [ContractTypes.AirSwapPool]: "0xbbcec987e4c189fcbab0a2534c77b3ba89229f11",
   },
   56: {

--- a/src/config/ContractAddresses.ts
+++ b/src/config/ContractAddresses.ts
@@ -2,6 +2,7 @@ export enum ContractTypes {
   AirSwapToken,
   AirSwapStaking,
   AirSwapPool,
+  AirSwapV3Staking_deprecated,
 }
 
 type ContractList = { [k in ContractTypes]?: `0x${string}` };
@@ -11,6 +12,8 @@ export const contractAddressesByChain: Record<number, ContractList> = {
     [ContractTypes.AirSwapToken]: "0x27054b13b1B798B345b591a4d22e6562d47eA75a",
     [ContractTypes.AirSwapStaking]:
       "0x9fc450F9AfE2833Eb44f9A1369Ab3678D3929860",
+    [ContractTypes.AirSwapV3Staking_deprecated]:
+      "0x6d88B09805b90dad911E5C5A512eEDd984D6860B",
     [ContractTypes.AirSwapPool]: "0xbbcec987e4c189fcbab0a2534c77b3ba89229f11",
   },
   5: {

--- a/src/contracts/v3StakingAbi.ts
+++ b/src/contracts/v3StakingAbi.ts
@@ -1,0 +1,42 @@
+// NOTE: This is a subset of the full ABI, only including the functions we need
+export const v3StakingAbi = [
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "available",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ internalType: "uint256", name: "total", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "getStakes",
+    outputs: [
+      {
+        components: [
+          { internalType: "uint256", name: "duration", type: "uint256" },
+          { internalType: "uint256", name: "balance", type: "uint256" },
+          { internalType: "uint256", name: "timestamp", type: "uint256" },
+        ],
+        internalType: "struct IStaking.Stake",
+        name: "accountStake",
+        type: "tuple",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "amount", type: "uint256" }],
+    name: "unstake",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;

--- a/src/features/staking/MigrationModal.tsx
+++ b/src/features/staking/MigrationModal.tsx
@@ -1,20 +1,172 @@
+import { AnimatePresence, motion } from "framer-motion";
 import { useEffect, useState } from "react";
+import { AiOutlineLoading } from "react-icons/ai";
+import { MdLaunch } from "react-icons/md";
+import { twJoin } from "tailwind-merge";
 import {
   useAccount,
   useContractRead,
   useContractWrite,
+  useNetwork,
   usePrepareContractWrite,
+  useSwitchNetwork,
 } from "wagmi";
+import { waitForTransaction } from "wagmi/actions";
 import { ContractTypes } from "../../config/ContractAddresses";
 import { useContractAddresses } from "../../config/hooks/useContractAddress";
 import { astAbi } from "../../contracts/astAbi";
+import { stakingAbi } from "../../contracts/stakingAbi";
 import { v3StakingAbi } from "../../contracts/v3StakingAbi";
 import { Button } from "../common/Button";
 import { Modal } from "../common/Modal";
 import { formatNumber } from "../common/utils/formatNumber";
 
+const MigrationStep = ({
+  stepNumber,
+  amount,
+  description,
+  isComplete,
+  isNextStep,
+  verb,
+  transactionHash,
+  isLoading,
+  buttonAction,
+}: {
+  stepNumber?: number;
+  amount: string;
+  verb: string;
+  description: string;
+  isComplete: boolean;
+  isNextStep: boolean;
+  isLoading?: boolean;
+  transactionHash?: string;
+  buttonAction?: () => void;
+}) => {
+  const { chain } = useNetwork();
+  const needsSwitchChain = isNextStep && chain?.id !== 1 && chain?.id !== 5;
+  const { switchNetwork } = useSwitchNetwork({ chainId: 1 });
+
+  return (
+    <>
+      <div
+        className={twJoin([
+          "grid place-items-center rounded-full w-10 h-10",
+          (isNextStep || isComplete) &&
+            "bg-airswap-blue text-gray-50 font-bold",
+          !isComplete &&
+            !isNextStep &&
+            "bg-transparent text-gray-300 font-bold border-gray-300 border",
+        ])}
+      >
+        {!isComplete ? (
+          <span className="relative -top-px">{stepNumber}</span>
+        ) : (
+          <svg
+            className="h-4 w-4"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+          >
+            <motion.path
+              key="check"
+              initial={{ pathLength: 0 }}
+              animate={{ pathLength: 1 }}
+              transition={{
+                duration: 0.8,
+              }}
+              d="M3,13 L9,19 22,5"
+              stroke={"currentColor"}
+              strokeWidth={3}
+            />
+          </svg>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <motion.h3
+          className={twJoin(
+            "inline-flex gap-2 items-center justify-between",
+            isNextStep ? "font-semibold" : !isComplete ? "text-gray-300" : "",
+          )}
+          animate={{ y: isComplete ? 22 : 0 }}
+          transition={{
+            ease: "easeOut",
+            duration: 0.5,
+          }}
+        >
+          {description}
+          {transactionHash && (
+            <motion.a
+              href={`https://etherscan.io/tx/${transactionHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="relative inline-flex items-center gap-1 top-px"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 0.9 }}
+              transition={{
+                ease: "easeOut",
+                duration: 1,
+                delay: 1,
+              }}
+            >
+              {" "}
+              <MdLaunch size={14} />
+            </motion.a>
+          )}
+        </motion.h3>
+        <Button
+          onClick={needsSwitchChain ? () => switchNetwork?.() : buttonAction}
+          color={isNextStep ? "primary" : "transparent"}
+          disabled={!isNextStep || isLoading}
+          className={twJoin(
+            "rounded-none text-sm p-2 transition-all",
+            isComplete && "!opacity-0 !pointer-events-none",
+          )}
+        >
+          <AnimatePresence>
+            {!isLoading && (
+              <motion.span initial={false} exit={{ opacity: 0 }}>
+                {needsSwitchChain ? (
+                  "Switch to mainnet"
+                ) : (
+                  <>
+                    {verb} {amount} AST
+                  </>
+                )}
+              </motion.span>
+            )}
+            {isLoading && (
+              <motion.span
+                className="inline-flex justify-center items-center gap-2 relative"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+              >
+                <span className="-my-2 absolute -left-7 top-2">
+                  <AiOutlineLoading
+                    className="animate-spin absolute"
+                    size={18}
+                  />
+                </span>
+                <span>
+                  {verb.replace(/e$/, "")}ing {amount} AST...
+                </span>
+              </motion.span>
+            )}
+          </AnimatePresence>
+        </Button>
+      </div>
+    </>
+  );
+};
+
 export const MigrationModal = ({}: {}) => {
   const [showMigrationModal, setShowMigrationModal] = useState<boolean>(true);
+  const [transactionHashes, setTransactionHashes] = useState<`0x${string}`[]>(
+    [],
+  );
+  const [isMining, setIsMining] = useState<boolean[]>([false, false, false]);
+  const [currentStep, setCurrentStep] = useState<number>(0);
 
   const { address: connectedAccount } = useAccount();
 
@@ -29,13 +181,6 @@ export const MigrationModal = ({}: {}) => {
     );
 
   /* ---------------------------- Contract reads ---------------------------- */
-  const { data: v3StakingBalance } = useContractRead({
-    abi: v3StakingAbi,
-    ...oldStakingContract,
-    functionName: "balanceOf",
-    args: [connectedAccount!],
-    enabled: !!connectedAccount,
-  });
   const { data: v3AvailableBalance } = useContractRead({
     abi: v3StakingAbi,
     ...oldStakingContract,
@@ -52,34 +197,96 @@ export const MigrationModal = ({}: {}) => {
     watch: true,
   });
 
+  // Save initial amount so we can show the amount even after it's gone.
+  const [initialAmount, setInitialAmount] = useState<bigint>();
+  useEffect(() => {
+    if (v3AvailableBalance && !initialAmount) {
+      setInitialAmount(v3AvailableBalance);
+    }
+  }, [v3AvailableBalance, initialAmount]);
+
+  const needsApproval =
+    initialAmount && initialAmount > (newStakingAstAllowance || 0n);
+
   /* ---------------------------- Contract writes --------------------------- */
+
+  // Unstake.
   const { config: unstakeConfig } = usePrepareContractWrite({
     abi: v3StakingAbi,
     ...oldStakingContract,
     functionName: "unstake",
-    args: [v3AvailableBalance!],
-    enabled: Boolean(connectedAccount && v3AvailableBalance),
+    args: [initialAmount!],
+    enabled: Boolean(
+      connectedAccount && v3AvailableBalance && currentStep === 0,
+    ),
   });
-  const { write: unstake, isLoading: unstakeLoading } =
-    useContractWrite(unstakeConfig);
 
-  // Save initial amount so we can show the amount even after it's gone.
-  const [initialAmount, setInitialAmount] = useState<bigint>();
-  useEffect(() => {
-    if (v3AvailableBalance) {
-      setInitialAmount(v3AvailableBalance);
-    }
-  }, [v3AvailableBalance]);
+  const { write: unstake, isLoading: unstakeLoading } = useContractWrite({
+    ...unstakeConfig,
+    onSuccess: async (result) => {
+      const hash = result.hash;
+      setIsMining([true, false, false]);
+      await waitForTransaction({
+        chainId: oldStakingContract.chainId,
+        hash,
+      });
+      setIsMining([false, false, false]);
+      setTransactionHashes((prev) => [...prev, hash]);
+      setCurrentStep(needsApproval ? 1 : 2);
+    },
+  });
 
-  const needsApproval =
-    initialAmount && initialAmount > (newStakingAstAllowance || 0n);
-  const isFullMigration =
-    v3StakingBalance === 0n || v3AvailableBalance === v3StakingBalance;
+  // Approve.
+  const { config: approveConfig } = usePrepareContractWrite({
+    abi: astAbi,
+    ...astContract,
+    functionName: "approve",
+    args: [newStakingContract.address!, initialAmount!],
+    enabled: Boolean(currentStep === 1),
+  });
+  const { write: approve, isLoading: approveLoading } = useContractWrite({
+    ...approveConfig,
+    onSuccess: async (result) => {
+      const hash = result.hash;
+      setIsMining([false, true, false]);
+      await waitForTransaction({
+        chainId: astContract.chainId,
+        hash,
+      });
+      setIsMining([false, false, false]);
+      setTransactionHashes((prev) => [...prev, hash]);
+      setCurrentStep(2);
+    },
+  });
+
+  // Restake.
+  const { config: stakeConfig } = usePrepareContractWrite({
+    abi: stakingAbi,
+    ...newStakingContract,
+    functionName: "stake",
+    args: [initialAmount!],
+    enabled: Boolean(currentStep === 2),
+  });
+  const { write: stake, isLoading: stakeLoading } = useContractWrite({
+    ...stakeConfig,
+    onSuccess: async (result) => {
+      const hash = result.hash;
+      setIsMining([false, false, true]);
+      await waitForTransaction({
+        chainId: newStakingContract.chainId,
+        hash,
+      });
+      setIsMining([false, false, false]);
+      setTransactionHashes((prev) => [...prev, hash]);
+      setCurrentStep(3);
+    },
+  });
 
   const formattedInitialAmount = formatNumber(initialAmount, 4);
 
   return (
-    showMigrationModal && (
+    showMigrationModal &&
+    (initialAmount || 0n) > 0n && (
       <Modal
         className="max-w-sm"
         onCloseRequest={() => setShowMigrationModal(false)}
@@ -108,41 +315,60 @@ export const MigrationModal = ({}: {}) => {
             gridTemplateColumns: "auto 1fr",
           }}
         >
-          <div className="grid place-items-center rounded-full w-10 h-10 bg-airswap-blue text-gray-50 font-bold">
-            <span className="relative -top-px left-px">1</span>
-          </div>
-          <div className="flex flex-col gap-2">
-            <h3 className="font-semibold">Unstake from the V3 contract</h3>
-            <Button color="primary" className="rounded-none text-sm p-2">
-              Unstake {formattedInitialAmount} AST
-            </Button>
-          </div>
+          <MigrationStep
+            verb="Unstake"
+            stepNumber={1}
+            amount={formattedInitialAmount || ""}
+            description="Unstake from the V3 contract"
+            isComplete={Boolean(transactionHashes[0])}
+            transactionHash={transactionHashes[0]}
+            isNextStep={currentStep === 0}
+            isLoading={unstakeLoading || isMining[0]}
+            buttonAction={unstake}
+          />
+          <MigrationStep
+            verb="Approve"
+            stepNumber={2}
+            amount={formattedInitialAmount || ""}
+            description="Approve the new staking contract"
+            isComplete={!needsApproval || Boolean(transactionHashes[1])}
+            transactionHash={transactionHashes[1]}
+            isNextStep={currentStep === 1}
+            isLoading={approveLoading || isMining[1]}
+            buttonAction={approve}
+          />
 
-          <div className="grid place-items-center rounded-full w-10 h-10 bg-transparent text-gray-300 font-bold border-gray-300 border">
-            <span className="relative -top-px left-px">2</span>
-          </div>
-          <div className="flex flex-col gap-2 text-gray-300">
-            <h3 className="">Approve the new staking contract</h3>
-            <Button
-              color="transparent"
-              className="rounded-none text-sm p-2 text-gray-400"
-            >
-              Approve {formattedInitialAmount} AST
-            </Button>
-          </div>
+          <MigrationStep
+            verb="Stake"
+            stepNumber={3}
+            amount={formattedInitialAmount || ""}
+            description="Stake using the new contract"
+            isComplete={Boolean(transactionHashes[2])}
+            isNextStep={currentStep === 2}
+            isLoading={stakeLoading || isMining[2]}
+            buttonAction={stake}
+            transactionHash={transactionHashes[2]}
+          />
 
-          <div className="grid place-items-center rounded-full w-10 h-10 bg-transparent text-gray-300 font-bold border-gray-300 border">
-            <span className="relative -top-px left-px">3</span>
-          </div>
-          <div className="flex flex-col gap-2 text-gray-300">
-            <h3 className="">Stake using the new contract</h3>
-            <Button
-              color="transparent"
-              className="rounded-none text-sm p-2 text-gray-400"
-            >
-              Stake {formattedInitialAmount} AST
-            </Button>
-          </div>
+          <motion.div
+            animate={{ height: currentStep === 3 ? "auto" : "0" }}
+            initial={{ height: 0 }}
+            className="col-span-full overflow-hidden"
+          >
+            <hr className=" border-gray-800 -mx-6 mb-6" />
+            <div className="flex flex-row justify-between items-center gap-4">
+              <div>
+                <div>All done!</div>
+                <div>The migration is now complete</div>
+              </div>
+              <Button
+                color="primary"
+                onClick={() => setShowMigrationModal(false)}
+              >
+                Close
+              </Button>
+            </div>
+          </motion.div>
         </div>
       </Modal>
     )

--- a/src/features/staking/MigrationModal.tsx
+++ b/src/features/staking/MigrationModal.tsx
@@ -277,7 +277,7 @@ export const MigrationModal = ({}: {}) => {
         hash,
       });
       setIsMining([false, false, false]);
-      setTransactionHashes((prev) => [...prev, hash]);
+      setTransactionHashes((prev) => [prev[0], prev[1], hash]);
       setCurrentStep(3);
     },
   });

--- a/src/features/staking/MigrationModal.tsx
+++ b/src/features/staking/MigrationModal.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from "react";
+import {
+  useAccount,
+  useContractRead,
+  useContractWrite,
+  usePrepareContractWrite,
+} from "wagmi";
+import { ContractTypes } from "../../config/ContractAddresses";
+import { useContractAddresses } from "../../config/hooks/useContractAddress";
+import { astAbi } from "../../contracts/astAbi";
+import { v3StakingAbi } from "../../contracts/v3StakingAbi";
+import { Button } from "../common/Button";
+import { Modal } from "../common/Modal";
+import { formatNumber } from "../common/utils/formatNumber";
+
+export const MigrationModal = ({}: {}) => {
+  const [showMigrationModal, setShowMigrationModal] = useState<boolean>(true);
+
+  const { address: connectedAccount } = useAccount();
+
+  const [newStakingContract, oldStakingContract, astContract] =
+    useContractAddresses(
+      [
+        ContractTypes.AirSwapStaking,
+        ContractTypes.AirSwapV3Staking_deprecated,
+        ContractTypes.AirSwapToken,
+      ],
+      { defaultChainId: 1, useDefaultAsFallback: true },
+    );
+
+  /* ---------------------------- Contract reads ---------------------------- */
+  const { data: v3StakingBalance } = useContractRead({
+    abi: v3StakingAbi,
+    ...oldStakingContract,
+    functionName: "balanceOf",
+    args: [connectedAccount!],
+    enabled: !!connectedAccount,
+  });
+  const { data: v3AvailableBalance } = useContractRead({
+    abi: v3StakingAbi,
+    ...oldStakingContract,
+    functionName: "available",
+    args: [connectedAccount!],
+    enabled: !!connectedAccount,
+  });
+  const { data: newStakingAstAllowance } = useContractRead({
+    abi: astAbi,
+    ...astContract,
+    functionName: "allowance",
+    args: [connectedAccount!, newStakingContract.address!],
+    enabled: !!connectedAccount,
+    watch: true,
+  });
+
+  /* ---------------------------- Contract writes --------------------------- */
+  const { config: unstakeConfig } = usePrepareContractWrite({
+    abi: v3StakingAbi,
+    ...oldStakingContract,
+    functionName: "unstake",
+    args: [v3AvailableBalance!],
+    enabled: Boolean(connectedAccount && v3AvailableBalance),
+  });
+  const { write: unstake, isLoading: unstakeLoading } =
+    useContractWrite(unstakeConfig);
+
+  // Save initial amount so we can show the amount even after it's gone.
+  const [initialAmount, setInitialAmount] = useState<bigint>();
+  useEffect(() => {
+    if (v3AvailableBalance) {
+      setInitialAmount(v3AvailableBalance);
+    }
+  }, [v3AvailableBalance]);
+
+  const needsApproval =
+    initialAmount && initialAmount > (newStakingAstAllowance || 0n);
+  const isFullMigration =
+    v3StakingBalance === 0n || v3AvailableBalance === v3StakingBalance;
+
+  const formattedInitialAmount = formatNumber(initialAmount, 4);
+
+  return (
+    showMigrationModal && (
+      <Modal
+        className="max-w-sm"
+        onCloseRequest={() => setShowMigrationModal(false)}
+        heading="Migrate to V4!"
+        subHeading={
+          <span className="[text-wrap:balance]">
+            Stake using the new contract to continue voting and earning rewards
+          </span>
+        }
+      >
+        <div className="flex flex-col gap-2">
+          <p>
+            You are currently staking {formattedInitialAmount} AST in the V3
+            staking contract.
+          </p>
+          <p>
+            After 31st December 2023 you will no longer be able to vote with AST
+            staked in this way. Please migrate at your earliest convenience by
+            following the steps below.
+          </p>
+        </div>
+
+        <div
+          className="grid grid-cols-2 mt-8 gap-4 items-center"
+          style={{
+            gridTemplateColumns: "auto 1fr",
+          }}
+        >
+          <div className="grid place-items-center rounded-full w-10 h-10 bg-airswap-blue text-gray-50 font-bold">
+            <span className="relative -top-px left-px">1</span>
+          </div>
+          <div className="flex flex-col gap-2">
+            <h3 className="font-semibold">Unstake from the V3 contract</h3>
+            <Button color="primary" className="rounded-none text-sm p-2">
+              Unstake {formattedInitialAmount} AST
+            </Button>
+          </div>
+
+          <div className="grid place-items-center rounded-full w-10 h-10 bg-transparent text-gray-300 font-bold border-gray-300 border">
+            <span className="relative -top-px left-px">2</span>
+          </div>
+          <div className="flex flex-col gap-2 text-gray-300">
+            <h3 className="">Approve the new staking contract</h3>
+            <Button
+              color="transparent"
+              className="rounded-none text-sm p-2 text-gray-400"
+            >
+              Approve {formattedInitialAmount} AST
+            </Button>
+          </div>
+
+          <div className="grid place-items-center rounded-full w-10 h-10 bg-transparent text-gray-300 font-bold border-gray-300 border">
+            <span className="relative -top-px left-px">3</span>
+          </div>
+          <div className="flex flex-col gap-2 text-gray-300">
+            <h3 className="">Stake using the new contract</h3>
+            <Button
+              color="transparent"
+              className="rounded-none text-sm p-2 text-gray-400"
+            >
+              Stake {formattedInitialAmount} AST
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    )
+  );
+};


### PR DESCRIPTION
https://github.com/airswap/airswap-voter-rewards/assets/82473383/4bfcaaac-3eb4-4998-92a2-d580ba9f6499

Note that when testing on Goerli you will need to mint some of the v4 AST and approve the staking contract manually because the v3 staking contract accepts a different token to v4. The video above shows the migration with the token preapproved.

[v4 ast](https://goerli.etherscan.io/address/0x7eef7238fd4f65312a53c5d195e675068afbb1d0#writeContract)
Staking address: `0x3BeC6526366cb2C2A609eb2bCeC8A696C141a33e`