### PR TITLE
Add a dashboard for Splits

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.47.0",
     "react-icons": "^4.11.0",
+    "recharts": "^2.9.3",
     "tailwind-merge": "^1.14.0",
     "tailwind-variants": "^0.1.14",
     "truncate-eth-address": "^1.0.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { ClaimFloat } from "./features/votes/ClaimFloat";
 import { VoteList } from "./features/votes/VoteList";
 import { useClaimSelectionStore } from "./features/votes/store/useClaimSelectionStore";
 import { useApplyTheme } from "./hooks/useApplyTheme";
+import { ClaimableAssetList } from "./features/votes/ClaimableAssetList";
 
 function App() {
   useApplyTheme();
@@ -15,7 +16,11 @@ function App() {
     <div className="flex flex-col flex-1 h-full items-center">
       <Header />
       <main className="mx-auto flex w-[808px] p-0 xs:p-2 max-w-full flex-col flex-1">
-        {isConnected ? <VoteList /> : <DisconnectedState />}
+        {isConnected ? <>
+          <ClaimableAssetList />
+          <VoteList />
+          <div className="h-28" />
+        </> : <DisconnectedState />}
       </main>
       <ClaimFloat onClaimClicked={() => setShowClaimModal(true)} />
     </div>

--- a/src/config/ContractAddresses.ts
+++ b/src/config/ContractAddresses.ts
@@ -2,6 +2,7 @@ export enum ContractTypes {
   AirSwapToken,
   AirSwapStaking,
   AirSwapPool,
+  SplitsMain
 }
 
 type ContractList = { [k in ContractTypes]?: `0x${string}` };
@@ -12,6 +13,7 @@ export const contractAddressesByChain: Record<number, ContractList> = {
     [ContractTypes.AirSwapStaking]:
       "0x9fc450F9AfE2833Eb44f9A1369Ab3678D3929860",
     [ContractTypes.AirSwapPool]: "0xbbcec987e4c189fcbab0a2534c77b3ba89229f11",
+    [ContractTypes.SplitsMain]: "0x2ed6c4B5dA6378c7897AC67Ba9e43102Feb694EE",
   },
   5: {
     // goerli

--- a/src/contracts/splitsAbi.ts
+++ b/src/contracts/splitsAbi.ts
@@ -1,0 +1,734 @@
+export const splitsAbi = [
+  {
+    inputs: [],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    inputs: [],
+    name: "Create2Error",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "CreateError",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "newController",
+        type: "address",
+      },
+    ],
+    name: "InvalidNewController",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "accountsLength",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "allocationsLength",
+        type: "uint256",
+      },
+    ],
+    name: "InvalidSplit__AccountsAndAllocationsMismatch",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "index",
+        type: "uint256",
+      },
+    ],
+    name: "InvalidSplit__AccountsOutOfOrder",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "index",
+        type: "uint256",
+      },
+    ],
+    name: "InvalidSplit__AllocationMustBePositive",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint32",
+        name: "allocationsSum",
+        type: "uint32",
+      },
+    ],
+    name: "InvalidSplit__InvalidAllocationsSum",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint32",
+        name: "distributorFee",
+        type: "uint32",
+      },
+    ],
+    name: "InvalidSplit__InvalidDistributorFee",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "hash",
+        type: "bytes32",
+      },
+    ],
+    name: "InvalidSplit__InvalidHash",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "accountsLength",
+        type: "uint256",
+      },
+    ],
+    name: "InvalidSplit__TooFewAccounts",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+    ],
+    name: "Unauthorized",
+    type: "error",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+    ],
+    name: "CancelControlTransfer",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "previousController",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newController",
+        type: "address",
+      },
+    ],
+    name: "ControlTransfer",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+    ],
+    name: "CreateSplit",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "contract ERC20",
+        name: "token",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "distributorAddress",
+        type: "address",
+      },
+    ],
+    name: "DistributeERC20",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "distributorAddress",
+        type: "address",
+      },
+    ],
+    name: "DistributeETH",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newPotentialController",
+        type: "address",
+      },
+    ],
+    name: "InitiateControlTransfer",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+    ],
+    name: "UpdateSplit",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "ethAmount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "contract ERC20[]",
+        name: "tokens",
+        type: "address[]",
+      },
+      {
+        indexed: false,
+        internalType: "uint256[]",
+        name: "tokenAmounts",
+        type: "uint256[]",
+      },
+    ],
+    name: "Withdrawal",
+    type: "event",
+  },
+  {
+    inputs: [],
+    name: "PERCENTAGE_SCALE",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+    ],
+    name: "acceptControl",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+    ],
+    name: "cancelControlTransfer",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address[]",
+        name: "accounts",
+        type: "address[]",
+      },
+      {
+        internalType: "uint32[]",
+        name: "percentAllocations",
+        type: "uint32[]",
+      },
+      {
+        internalType: "uint32",
+        name: "distributorFee",
+        type: "uint32",
+      },
+      {
+        internalType: "address",
+        name: "controller",
+        type: "address",
+      },
+    ],
+    name: "createSplit",
+    outputs: [
+      {
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+      {
+        internalType: "contract ERC20",
+        name: "token",
+        type: "address",
+      },
+      {
+        internalType: "address[]",
+        name: "accounts",
+        type: "address[]",
+      },
+      {
+        internalType: "uint32[]",
+        name: "percentAllocations",
+        type: "uint32[]",
+      },
+      {
+        internalType: "uint32",
+        name: "distributorFee",
+        type: "uint32",
+      },
+      {
+        internalType: "address",
+        name: "distributorAddress",
+        type: "address",
+      },
+    ],
+    name: "distributeERC20",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+      {
+        internalType: "address[]",
+        name: "accounts",
+        type: "address[]",
+      },
+      {
+        internalType: "uint32[]",
+        name: "percentAllocations",
+        type: "uint32[]",
+      },
+      {
+        internalType: "uint32",
+        name: "distributorFee",
+        type: "uint32",
+      },
+      {
+        internalType: "address",
+        name: "distributorAddress",
+        type: "address",
+      },
+    ],
+    name: "distributeETH",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+    ],
+    name: "getController",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        internalType: "contract ERC20",
+        name: "token",
+        type: "address",
+      },
+    ],
+    name: "getERC20Balance",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+    ],
+    name: "getETHBalance",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+    ],
+    name: "getHash",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+    ],
+    name: "getNewPotentialController",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+    ],
+    name: "makeSplitImmutable",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address[]",
+        name: "accounts",
+        type: "address[]",
+      },
+      {
+        internalType: "uint32[]",
+        name: "percentAllocations",
+        type: "uint32[]",
+      },
+      {
+        internalType: "uint32",
+        name: "distributorFee",
+        type: "uint32",
+      },
+    ],
+    name: "predictImmutableSplitAddress",
+    outputs: [
+      {
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "newController",
+        type: "address",
+      },
+    ],
+    name: "transferControl",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+      {
+        internalType: "contract ERC20",
+        name: "token",
+        type: "address",
+      },
+      {
+        internalType: "address[]",
+        name: "accounts",
+        type: "address[]",
+      },
+      {
+        internalType: "uint32[]",
+        name: "percentAllocations",
+        type: "uint32[]",
+      },
+      {
+        internalType: "uint32",
+        name: "distributorFee",
+        type: "uint32",
+      },
+      {
+        internalType: "address",
+        name: "distributorAddress",
+        type: "address",
+      },
+    ],
+    name: "updateAndDistributeERC20",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+      {
+        internalType: "address[]",
+        name: "accounts",
+        type: "address[]",
+      },
+      {
+        internalType: "uint32[]",
+        name: "percentAllocations",
+        type: "uint32[]",
+      },
+      {
+        internalType: "uint32",
+        name: "distributorFee",
+        type: "uint32",
+      },
+      {
+        internalType: "address",
+        name: "distributorAddress",
+        type: "address",
+      },
+    ],
+    name: "updateAndDistributeETH",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "split",
+        type: "address",
+      },
+      {
+        internalType: "address[]",
+        name: "accounts",
+        type: "address[]",
+      },
+      {
+        internalType: "uint32[]",
+        name: "percentAllocations",
+        type: "uint32[]",
+      },
+      {
+        internalType: "uint32",
+        name: "distributorFee",
+        type: "uint32",
+      },
+    ],
+    name: "updateSplit",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "walletImplementation",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "withdrawETH",
+        type: "uint256",
+      },
+      {
+        internalType: "contract ERC20[]",
+        name: "tokens",
+        type: "address[]",
+      },
+    ],
+    name: "withdraw",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    stateMutability: "payable",
+    type: "receive",
+  },
+] as const;

--- a/src/features/votes/ClaimableAssetList.tsx
+++ b/src/features/votes/ClaimableAssetList.tsx
@@ -1,0 +1,81 @@
+import { Bar, BarChart, LabelList, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { useSplitsAmounts } from "../../hooks/useSplitsAmounts";
+import { formatNumber } from "../common/utils/formatNumber";
+
+export const ClaimableAssetList = ({ }: {}) => {
+
+  let splitsAmountsResults = useSplitsAmounts();
+  const max = splitsAmountsResults[0].data?.totalUsdValue || 0;
+
+  return (
+    <div className="flex flex-col gap-4 p-4 relative flex-1">
+      <div className="flex flex-row items-center gap-4">
+        <h3 className="text-xs font-bold uppercase text-gray-500">
+          Dashboard
+        </h3>
+        <div className="h-px flex-1 bg-gray-800"></div>
+      </div>
+      <div>
+        <ResponsiveContainer width="100%" height={splitsAmountsResults.length * 30}>
+          <BarChart layout="vertical" data={splitsAmountsResults.map((result) => result.data)}>
+            <Legend verticalAlign="top" />
+            <Bar name="To distribute" dataKey="toDistributeUsdValue" stackId="a" fill="#ffc658" />
+            <Bar name="To withdraw" dataKey="toWithdrawUsdValue" stackId="a" fill="#82ca9d" />
+            <Bar name="Pool" dataKey="claimableUsdValue" stackId="a" fill="#8884d8">
+              <LabelList dataKey="totalUsdValue" position="insideRight" formatter={formatAmount} className="fill-white opacity-75 text-sm" />
+            </Bar>
+            <Tooltip cursor={false} content={<CustomTooltip />} wrapperClassName="shadow shadow-xl" formatter={formatAmount} />
+            <XAxis type="number" hide={true} domain={[0, max]} />
+            <YAxis type="category" dataKey="tokenInfo.symbol" interval={0} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}
+
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="bg-gray-900 rounded-md border border-gray-800">
+        <table>
+          <thead>
+            <tr className="text-left">
+              <th className="px-2 w-32 border-r border-gray-800">{label}</th>
+              <th className="px-2 border-r border-gray-800">Amount</th>
+              <th className="px-2">USD value</th>
+            </tr>
+          </thead>
+          <tbody className="text-gray-500">
+            <tr className="border-t border-gray-800">
+              <td className="px-2 font-semibold" style={{ color: payload[0].color }}>{payload[0].name}</td>
+              <td className="px-2 border-r border-gray-800">{formatNumber(payload[0].payload.toDistribute)}</td>
+              <td className="px-2 text-right tabular-nums">{formatAmount(payload[0].value)}</td>
+            </tr>
+            <tr className="border-t border-gray-800">
+              <td className="px-2 border-r border-gray-800 font-semibold" style={{ color: payload[1].color }}>{payload[1].name}</td>
+              <td className="px-2 border-r border-gray-800">{formatNumber(payload[1].payload.toWithdraw)}</td>
+              <td className="px-2 text-right tabular-nums">{formatAmount(payload[1].value)}</td>
+            </tr>
+            <tr className="border-t border-gray-800">
+              <td className="px-2 border-r border-gray-800 font-semibold" style={{ color: payload[2].color }}>{payload[2].name}</td>
+              <td className="px-2 border-r border-gray-800">{formatNumber(payload[2].payload.claimable)}</td>
+              <td className="px-2 text-right tabular-nums">{formatAmount(payload[2].value)}</td>
+            </tr>
+            <tr className="border-t border-gray-800">
+              <td className="px-2 text-white border-r border-gray-800 font-semibold">Total</td>
+              <td className="px-2 border-r border-gray-800">{formatNumber(payload[0].payload.total)}</td>
+              <td className="px-2 text-right tabular-nums">{formatAmount(payload[0].payload.totalUsdValue)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+const formatAmount = (amount: number): string => {
+  return "$" + amount.toFixed(2);
+}

--- a/src/features/votes/VoteList.tsx
+++ b/src/features/votes/VoteList.tsx
@@ -37,16 +37,16 @@ export const VoteList = ({}: {}) => {
   const liveProposalGroups = rootsLoading
     ? []
     : proposalGroups?.filter(
-        (proposals, i) =>
-          proposals[0].end * 1000 > Date.now() || rootQueries[i].data == null,
-      );
+      (proposals, i) =>
+        proposals[0].end * 1000 > Date.now() || rootQueries[i].data == null,
+    );
 
   const pastProposalGroups = rootsLoading
     ? []
     : proposalGroups?.filter(
-        (proposals, i) =>
-          proposals[0].end * 1000 < Date.now() && rootQueries[i].data != null,
-      );
+      (proposals, i) =>
+        proposals[0].end * 1000 < Date.now() && rootQueries[i].data != null,
+    );
 
   const showLoadingState = proposalGroupsLoading || rootsLoading;
 
@@ -106,7 +106,6 @@ export const VoteList = ({}: {}) => {
           )}
 
           <ActivatePointsCard />
-          <div className="h-28" />
         </>
       )}
 

--- a/src/hooks/useSplitsAmounts.tsx
+++ b/src/hooks/useSplitsAmounts.tsx
@@ -1,0 +1,92 @@
+import { Address, useChainId } from "wagmi";
+import { SupportedChainId, useDefiLlamaBatchPrices } from "../features/claims/hooks/useDefillamaBatchPrices";
+import { TestnetClaimableToken, claimableTokens, testnetClaimableTokens } from "../features/claims/config/claimableTokens";
+import { useMultipleTokenInfo } from "../features/common/hooks/useMultipleTokenInfo";
+import { useSplitsBalances } from "./useSplitsBalances";
+import { useMemo } from "react";
+import BigNumber from "bignumber.js";
+
+const testnets = Object.keys(testnetClaimableTokens).map((t) => parseInt(t));
+
+export const useSplitsAmounts = () => {
+  const chainId = useChainId() as SupportedChainId;
+
+  const isTestnet = testnets.includes(chainId);
+
+  const tokenList = isTestnet
+    ? testnetClaimableTokens[chainId]
+    : claimableTokens[chainId];
+
+  const tokenAddresses = isTestnet
+    ? (tokenList as TestnetClaimableToken[]).map((t) => t.address)
+    : (tokenList as Address[]);
+
+  const tokenInfoResults = useMultipleTokenInfo({
+    chainId,
+    tokenAddresses: tokenAddresses,
+  });
+
+  const { data: prices } = useDefiLlamaBatchPrices({
+    chainId,
+    tokenAddresses: tokenList.map((token) =>
+      typeof token === "object" ? token.mainnetEquivalentAddress : token,
+    ),
+  });
+
+  const splitsBalancesResults = useSplitsBalances({ chainId, tokenAddresses });
+
+  return useMemo(() => {
+    return tokenList
+      .map((_, index) => {
+        const tokenInfo = tokenInfoResults[index].data;
+        const price = prices?.[index].price;
+        const splitsBalances = splitsBalancesResults[index].data;
+
+        if (tokenInfo === undefined ||
+          tokenInfo.decimals === undefined ||
+          price === undefined ||
+          splitsBalances === undefined ||
+          splitsBalances.toDistribute === undefined ||
+          splitsBalances.toWithdraw === undefined ||
+          splitsBalances.claimable === undefined) {
+          return {
+            isLoading: true,
+            data: undefined
+          }
+        }
+        else {
+          const toDistribute =
+            new BigNumber(splitsBalances.toDistribute.toString())
+              .dividedBy(10 ** tokenInfo.decimals);
+
+          const toWithdraw =
+            new BigNumber(splitsBalances.toWithdraw.toString())
+              .dividedBy(10 ** tokenInfo.decimals);
+
+          const claimable =
+            new BigNumber(splitsBalances.claimable.toString())
+              .dividedBy(10 ** tokenInfo.decimals);
+
+          const total = toDistribute.plus(toWithdraw).plus(claimable);
+
+          return {
+            isLoading: false,
+            data: {
+              tokenInfo,
+              price,
+              toDistribute: toDistribute.toNumber(),
+              toDistributeUsdValue: toDistribute.multipliedBy(price).toNumber(),
+              toWithdraw: toWithdraw.toNumber(),
+              toWithdrawUsdValue: toWithdraw.multipliedBy(price).toNumber(),
+              claimable: claimable.toNumber(),
+              claimableUsdValue: claimable.multipliedBy(price).toNumber(),
+              total: total.toNumber(),
+              totalUsdValue: total.multipliedBy(price).toNumber()
+            }
+          };
+        }
+      })
+      .sort((a, b) => (b.data?.totalUsdValue || 0) - (a.data?.totalUsdValue || 0));
+
+  }, [prices, tokenInfoResults, splitsBalancesResults, tokenList]);
+}

--- a/src/hooks/useSplitsBalances.tsx
+++ b/src/hooks/useSplitsBalances.tsx
@@ -1,0 +1,90 @@
+import { fetchBalance, multicall } from "wagmi/actions";
+import { splitsAbi } from "../contracts/splitsAbi";
+import { useContractAddresses } from "../config/hooks/useContractAddress";
+import { ContractTypes } from "../config/ContractAddresses";
+import { useQueries } from "@tanstack/react-query";
+
+
+type SplitsBalancesQueryKey = [
+  chainId: number,
+  tokenAddress: `0x${string}`,
+  splitsMainAddress: `0x${string}`,
+  airSwapPoolAddress: `0x${string}`,
+  splitsBalances: "splitsBalances",
+];
+
+const splitWallets: Record<number, `0x${string}`> = {
+  1: "0xaD30f7EEBD9Bd5150a256F47DA41d4403033CdF0"
+}
+
+const fetchSplitsBalances = async ({
+  queryKey: [chainId, tokenAddress, splitsMainAddress, airSwapPoolAddress],
+}: {
+  queryKey: SplitsBalancesQueryKey;
+}) => {
+  const claimable = await fetchBalance({ address: airSwapPoolAddress, token: tokenAddress, chainId });
+  const splitWallet = splitWallets[chainId];
+  if (splitWallet) {
+    const results = await multicall({
+      chainId,
+      contracts: [
+        {
+          address: splitsMainAddress,
+          abi: splitsAbi,
+          functionName: "getERC20Balance",
+          args: ["0xaD30f7EEBD9Bd5150a256F47DA41d4403033CdF0", tokenAddress],
+        },
+        {
+          address: splitsMainAddress,
+          abi: splitsAbi,
+          functionName: "getERC20Balance",
+          args: [airSwapPoolAddress, tokenAddress],
+        }
+      ],
+    });
+  
+  
+  
+    return {
+      address: tokenAddress,
+      toDistribute: results[0].result,
+      toWithdraw: results[1].result,
+      claimable: claimable.value
+    };
+  }
+  else {
+    return {
+      address: tokenAddress,
+      toDistribute: 0n,
+      toWithdraw: 0n,
+      claimable: claimable.value
+    };
+  }
+};
+
+export const useSplitsBalances = ({
+  chainId,
+  tokenAddresses,
+}: {
+  tokenAddresses?: `0x${string}`[];
+  chainId?: number;
+}) => {
+  const [splitsMain, airSwapPool] = useContractAddresses(
+    [ContractTypes.SplitsMain, ContractTypes.AirSwapPool],
+    {
+      defaultChainId: 1,
+      useDefaultAsFallback: true,
+    },
+  );
+
+  const queries = useQueries({
+    queries: tokenAddresses!.map((tokenAddress) => ({
+      queryKey: [chainId, tokenAddress, splitsMain.address!, airSwapPool.address!, "splitsBalances"] as SplitsBalancesQueryKey,
+      queryFn: fetchSplitsBalances,
+      cacheTime: 2_592_000_000, // 1 month
+    })),
+  });
+
+  return queries;
+
+}


### PR DESCRIPTION
As discussed on Discord, here is a first draft of a chart showing pool asset distribution, including splits.

![image](https://github.com/airswap/airswap-voter-rewards/assets/3535019/1aaa7268-cf3b-4649-b813-632fe851f01c)

I'm not sure if this should be integrated to the claim process or on a "Dashboard" page, wdyt?