### PR TITLE
Prevent new stakes, only allow full unstakes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { useAccount } from "wagmi";
-import { MigrationModal } from "./features/staking/MigrationModal";
 import { DisconnectedState } from "./features/structure/DisconnectedState";
 import { Header } from "./features/structure/Header";
 import { ClaimFloat } from "./features/votes/ClaimFloat";
@@ -18,7 +17,7 @@ function App() {
       <main className="mx-auto flex w-[808px] p-0 xs:p-2 max-w-full flex-col flex-1">
         {isConnected ? <VoteList /> : <DisconnectedState />}
       </main>
-      <MigrationModal />
+      {/* <MigrationModal /> */}
       <ClaimFloat onClaimClicked={() => setShowClaimModal(true)} />
     </div>
   );

--- a/src/features/staking/ManageStake.tsx
+++ b/src/features/staking/ManageStake.tsx
@@ -102,7 +102,7 @@ export const ManageStake = ({
           </div>
           <div>
             We are currently investigating an issue with the staking contract.
-            During this time new stakes are disabled unstaking is limited to
+            During this time new stakes are disabled and unstaking is limited to
             only your full balance when available.
           </div>
         </div>

--- a/src/features/staking/ManageStake.tsx
+++ b/src/features/staking/ManageStake.tsx
@@ -1,10 +1,11 @@
+import { useEffect } from "react";
 import { FieldValues, UseFormReturn } from "react-hook-form";
+import { IoMdAlert } from "react-icons/io";
 import { twJoin } from "tailwind-merge";
 import AirSwapLogo from "../../assets/airswap-logo.svg";
 import { useTokenBalances } from "../../hooks/useTokenBalances";
 import { Button } from "../common/Button";
 import { LineBreak } from "../common/LineBreak";
-import { formatNumber } from "../common/utils/formatNumber";
 import { NumberInput } from "./NumberInput";
 import { PieBar } from "./PieBar";
 import { useStakingModalStore } from "./store/useStakingModalStore";
@@ -22,10 +23,16 @@ export const ManageStake = ({
   const {
     unstakableSastBalanceRaw: unstakableBalance,
     astBalanceRaw: stakableBalance,
+    sAstBalanceRaw: sAstBalance,
   } = useTokenBalances();
 
-  const stakableBalanceFormatted = formatNumber(stakableBalance, 4) || 0;
-  const unstakableBalanceFormatted = formatNumber(unstakableBalance, 4) || 0;
+  useEffect(() => {
+    if (sAstBalance != null && unstakableBalance != null) {
+      if (sAstBalance === unstakableBalance) {
+        setValue("stakingAmount", Number(sAstBalance / 10000n));
+      }
+    }
+  }, [sAstBalance, unstakableBalance, setValue]);
 
   const handleSetMaxBalance = () => {
     if (txType === TxType.STAKE) {
@@ -59,6 +66,7 @@ export const ManageStake = ({
       <LineBreak className="relative mb-4 -mx-6" />
       <div className="font-lg pointer-cursor rounded-md font-semibold">
         <Button
+          disabled
           className={twJoin([
             "w-1/2 p-2",
             `${txType === "stake" ? "bg-gray-800" : "text-gray-500"}`,
@@ -88,9 +96,16 @@ export const ManageStake = ({
           "bg-gray-800 text-gray-400",
         )}
       >
-        Stake AST prior to voting on proposals. The amount of tokens you stake
-        determines the weight of your vote. Tokens unlock linearly over 20
-        weeks.
+        <div className="flex flex-row gap-2 items-start">
+          <div>
+            <IoMdAlert size={20} className="mt-1" />
+          </div>
+          <div>
+            We are currently investigating an issue with the staking contract.
+            During this time new stakes are disabled unstaking is limited to
+            only your full balance when available.
+          </div>
+        </div>
       </div>
       <div className="flex items-center justify-between rounded border border-gray-800 bg-gray-950 px-5 py-4">
         <img src={AirSwapLogo} alt="AirSwap Logo" className="h-8 w-8" />
@@ -99,11 +114,12 @@ export const ManageStake = ({
             <NumberInput formReturn={formReturn} />
           </div>
           <Button
+            disabled
             onClick={handleSetMaxBalance}
             color="darkGray"
             size="smaller"
-            rounded='small'
-            className="flex self-center ml-4 hover:bg-white"
+            rounded="small"
+            className="flex self-center ml-4 enabled:hover:bg-white"
           >
             max
           </Button>

--- a/src/features/staking/ManageStake.tsx
+++ b/src/features/staking/ManageStake.tsx
@@ -29,9 +29,9 @@ export const ManageStake = ({
 
   const handleSetMaxBalance = () => {
     if (txType === TxType.STAKE) {
-      setValue("stakingAmount", Number(stakableBalance) / 10 ** 4);
+      setValue("stakingAmount", Number(stakableBalance / 10000n));
     } else {
-      setValue("stakingAmount", Number(unstakableBalance) / 10 ** 4);
+      setValue("stakingAmount", Number(unstakableBalance / 10000n));
     }
   };
 

--- a/src/features/staking/NumberInput.tsx
+++ b/src/features/staking/NumberInput.tsx
@@ -19,6 +19,7 @@ export const NumberInput = ({
 
   return (
     <input
+      disabled
       max={Number(astBalance)}
       placeholder="0.00"
       autoComplete="off"
@@ -42,7 +43,7 @@ export const NumberInput = ({
       className={twJoin(
         "items-right w-1/5 bg-transparent text-right min-w-fit",
         "font-mono font-medium text-white text-[28px]",
-        "focus-visible:outline-none",
+        "focus-visible:outline-none disabled:text-opacity-50",
       )}
     />
   );

--- a/src/features/staking/StakingModal.tsx
+++ b/src/features/staking/StakingModal.tsx
@@ -125,7 +125,7 @@ export const StakingModal = () => {
     insufficientBalance: isInsufficientBalance,
   });
 
-  const isAmountInvalid = Number(stakingAmountFormatted || 0) * 10 ** 4 <= 0;
+  const isAmountInvalid = Number(stakingAmountFormatted || 0) <= 0;
 
   const isStakeButtonDisabled = isAmountInvalid || isInsufficientBalance;
 

--- a/src/features/staking/StakingModal.tsx
+++ b/src/features/staking/StakingModal.tsx
@@ -125,7 +125,7 @@ export const StakingModal = () => {
     insufficientBalance: isInsufficientBalance,
   });
 
-  const isAmountInvalid = Number(stakingAmountFormatted) * 10 ** 4 <= 0;
+  const isAmountInvalid = Number(stakingAmountFormatted || 0) * 10 ** 4 <= 0;
 
   const isStakeButtonDisabled = isAmountInvalid || isInsufficientBalance;
 

--- a/src/features/staking/store/useStakingModalStore.tsx
+++ b/src/features/staking/store/useStakingModalStore.tsx
@@ -20,7 +20,7 @@ const stakingModalStore = create<StakingModalStore>()(
         set({ showStakingModal: show });
       },
 
-      txType: TxType.STAKE,
+      txType: TxType.UNSTAKE,
       setTxType(change: TxType) {
         set({ txType: change });
       },


### PR DESCRIPTION
This change prevents new stakes (and migrations), and ensures unstakes are always for the full balance.

This prevents potential stuck AST due to a contract issue.

For testing, here is an address to impersonate with a fully vested stake: `0x948f567175AdDD02Af4dc3713Ad04523aF4b01D2`

There are many w/o fully vested stakes here:
`https://etherscan.io/token/0x9fc450F9AfE2833Eb44f9A1369Ab3678D3929860#balances`