### PR TITLE
Fix number formatting in token balances

### DIFF
--- a/src/features/staking/PieBar.tsx
+++ b/src/features/staking/PieBar.tsx
@@ -15,14 +15,15 @@ export const PieBar = () => {
   } = useTokenBalances();
 
   const unstaked = formatNumber(astBalanceRaw, 4) || 0;
-  const staked = formatNumber(sAstBalanceRaw, 4) || 0;
-  const unstakable = formatNumber(unstakableSastBalanceRaw, 4) || 0;
-  const unstakableV4 =
-    formatNumber(unstakableSastBalanceV4_DeprecatedRaw, 4) || 0;
-  const stakedV4 = formatNumber(sAstBalanceV4_DeprecatedRaw, 4) || 0;
 
-  const totalStaked = String(Number(staked) + Number(stakedV4));
-  const totalUnstakable = String(Number(unstakable) + Number(unstakableV4));
+  const totalStaked = formatNumber(
+    sAstBalanceRaw + sAstBalanceV4_DeprecatedRaw,
+    4,
+  );
+  const totalUnstakable = formatNumber(
+    unstakableSastBalanceRaw + unstakableSastBalanceV4_DeprecatedRaw,
+    4,
+  );
 
   // the following 2 values are only used for calculateTokenProportions
   const totalUnstakableRaw =

--- a/src/features/staking/StakingButton.tsx
+++ b/src/features/staking/StakingButton.tsx
@@ -11,10 +11,10 @@ export const StakingButton = () => {
   const { isConnected } = useAccount();
   const { sAstBalanceRaw, sAstBalanceV4_DeprecatedRaw } = useTokenBalances();
 
-  const sAstBalance = formatNumber(sAstBalanceRaw, 4) || 0;
-  const sAstBalanceV4 = formatNumber(sAstBalanceV4_DeprecatedRaw, 4) || 0;
-
-  const totalSastBalance = Number(sAstBalance) + Number(sAstBalanceV4);
+  const totalSastBalance = formatNumber(
+    sAstBalanceRaw + sAstBalanceV4_DeprecatedRaw,
+    4,
+  );
 
   return (
     <>


### PR DESCRIPTION
This pull request fixes the number formatting in the token balance calculations in the code. Previously, the formatting was incorrect, leading to incorrect display of token balances. This PR updates the formatting to ensure accurate representation of token balances.